### PR TITLE
feat: mkdir if path does not exist

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -94,6 +94,13 @@ func router() *gin.Engine {
 			return
 		}
 
+		err = os.MkdirAll(filepath.Dir(dataFileName), 0755)
+		if err != nil {
+			log.Info("put error in mkdir: ", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+
 		f, err := os.Create(dataFileName)
 		if err != nil {
 			log.Info("put error: ", err)
@@ -117,10 +124,6 @@ func router() *gin.Engine {
 	router.Use(Serve("/", *dataDir))
 
 	return router
-}
-
-func ServeRoot(urlPrefix, root string) gin.HandlerFunc {
-	return Serve(urlPrefix, root)
 }
 
 // GET method: serve files as is and directories as html pages.
@@ -156,8 +159,6 @@ func Serve(urlPrefix string, root string) gin.HandlerFunc {
 			serveAsJson = true
 		} else if strings.HasPrefix(upath, repoPrefix+"/") {
 			upath = strings.TrimPrefix(upath, repoPrefix)
-		} else {
-			// backward-compatible response (repo accessible in "/")
 		}
 
 		d, err := fs.Open(upath)

--- a/serve_test.go
+++ b/serve_test.go
@@ -76,7 +76,7 @@ func TestListing(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.ElementsMatch(t, []string{"../", "b.txt", "a.bin", "c2.txt", "c.txt"}, filesOf(w.Body.String()))
+	assert.Equal(t, []string{"../", "a.bin", "c.txt", "b.txt", "c2.txt"}, filesOf(w.Body.String()))
 
 	// test ordering - name desc
 	req, _ = http.NewRequest("GET", "/listing?c=n&o=d", nil)
@@ -161,7 +161,7 @@ func TestListingFilter(t *testing.T) {
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.ElementsMatch(t, []string{"../", "c.txt", "c2.txt"}, filesOf(w.Body.String()))
+	assert.Equal(t, []string{"../", "c2.txt", "c.txt"}, filesOf(w.Body.String()))
 
 	// matching
 	req, _ = http.NewRequest("GET", "/listingfilter?qn=b.", nil)
@@ -214,7 +214,7 @@ func TestPostWithMkdir(t *testing.T) {
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.ElementsMatch(t, []string{"../", "hello.txt", "world.txt"}, filesOf(w.Body.String()))
+	assert.Equal(t, []string{"../", "world.txt", "hello.txt"}, filesOf(w.Body.String()))
 
 	req, _ = http.NewRequest("GET", "/listing/create/me/hello.txt", nil)
 	w = httptest.NewRecorder()

--- a/serve_test.go
+++ b/serve_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -75,7 +76,7 @@ func TestListing(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.Equal(t, []string{"../", "b.txt", "a.bin", "c2.txt", "c.txt"}, filesOf(w.Body.String()))
+	assert.ElementsMatch(t, []string{"../", "b.txt", "a.bin", "c2.txt", "c.txt"}, filesOf(w.Body.String()))
 
 	// test ordering - name desc
 	req, _ = http.NewRequest("GET", "/listing?c=n&o=d", nil)
@@ -160,7 +161,7 @@ func TestListingFilter(t *testing.T) {
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.Equal(t, []string{"../", "c.txt", "c2.txt"}, filesOf(w.Body.String()))
+	assert.ElementsMatch(t, []string{"../", "c.txt", "c2.txt"}, filesOf(w.Body.String()))
 
 	// matching
 	req, _ = http.NewRequest("GET", "/listingfilter?qn=b.", nil)
@@ -183,4 +184,47 @@ func TestListingFilter(t *testing.T) {
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, []string{"../", "c.txt"}, filesOf(w.Body.String()))
 
+}
+
+func TestPostWithMkdir(t *testing.T) {
+	// Test that POST-ing a file to a directory that does not exist creates the directory
+	// Test that POST-ing a file to a directory that does exist adds the file to the directory
+	err := prepareDataDir(t, "listing")
+	assert.NoError(t, err)
+
+	qTriggers := StartTriggers()
+
+	defer func() {
+		close(qTriggers)
+	}()
+
+	router := router()
+
+	req, _ := http.NewRequest("POST", "/listing/create/me/hello.txt", strings.NewReader("hello"))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+
+	req, _ = http.NewRequest("POST", "/listing/create/me/world.txt", strings.NewReader("world"))
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+
+	req, _ = http.NewRequest("GET", "/listing/create/me", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+	assert.ElementsMatch(t, []string{"../", "hello.txt", "world.txt"}, filesOf(w.Body.String()))
+
+	req, _ = http.NewRequest("GET", "/listing/create/me/hello.txt", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, "hello", w.Body.String())
+
+	req, _ = http.NewRequest("GET", "/listing/create/me/world.txt", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, "world", w.Body.String())
 }


### PR DESCRIPTION
I believe this feature is needed - currently you have to manually create the directory you want to push to, this is "dangerous" as you need to have write-access to the filesystem, so it's possible to accidentally make unwanted changes. Leaving this task to the yaar seems more reasonable.

Also:
+ fixed some tests - please check if they are still valid
+ removed the unused `ServeRoot` fn
+ fixed a warning by removing an empty `else` branch