### PR TITLE
feat(api)!: refactor endpoints

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -5,7 +5,7 @@
     <title>Yaar artifactory browser</title>
 
     <script>
-        var apiPrefix = "/api/v1/meta";
+        var apiPrefix = "/api/v1/dirtree";
         var sortBy = "Time";
         var ascending = false;
         var maxNameLen = 0;

--- a/browser.html
+++ b/browser.html
@@ -5,7 +5,7 @@
     <title>Yaar artifactory browser</title>
 
     <script>
-        var apiPrefix = "/api/v1/dirtree";
+        var apiPrefix = "/api/v1/meta";
         var sortBy = "Time";
         var ascending = false;
         var maxNameLen = 0;

--- a/browser.html
+++ b/browser.html
@@ -5,7 +5,7 @@
     <title>Yaar artifactory browser</title>
 
     <script>
-        var apiPrefix = "/api/dirtree";
+        var apiPrefix = "/api/v1/dirtree";
         var sortBy = "Time";
         var ascending = false;
         var maxNameLen = 0;
@@ -118,24 +118,24 @@
         }
 
         function fetchDirectory(path) {
-            var xhr = new XMLHttpRequest();
-            xhr.onreadystatechange = function () {
-                document.title = path + '/ - yaar'
+
+            fetch(apiPrefix + path, {
+                method: 'GET',
+                headers: { 'Accept': 'application/json' },
+            }).then(response => {
+                if (!response.ok) {
+                    throw new Error('Network error');
+                }
+                return response.json();
+            }).then(data => {
+                document.title = path + '/ - yaar';
                 document.getElementById('dirname').innerText = path + '/';
                 document.getElementById('querytime').innerText = formatDate(new Date());
-                if (xhr.readyState === XMLHttpRequest.DONE) {
-                    if (xhr.status === 200) {
-                        processEntries(xhr.response);
-                    } else {
-                        console.error('Error fetching content');
-                        document.getElementById('filelist').innerHTML = 'Error fetching content';
-                    }
-                }
-            };
-            xhr.responseType = 'json';
-            var url = apiPrefix + (path !== '' ? path : '/');
-            xhr.open('GET', url, true);
-            xhr.send();
+                processEntries(data);
+            }).catch(error => {
+                console.error('Error fetching content:', error);
+                document.getElementById('filelist').innerHTML = 'Error fetching content';
+            });
         }
 
         // Function to handle navigation using fragment

--- a/serve.go
+++ b/serve.go
@@ -91,7 +91,7 @@ func handleUpload(c *gin.Context, allowOverwrite bool) {
 	triggers <- name
 }
 
-func handleMetaGet(c *gin.Context) {
+func handleDirtreeGet(c *gin.Context) {
 	name := c.Param("name")
 
 	httpDir := http.Dir(*dataDir)
@@ -144,9 +144,7 @@ func router() *gin.Engine {
 	// /api
 	api := router.Group("/api/v1")
 
-	// /api/meta
-	meta := api.Group("/meta")
-	meta.DELETE("/*name", func(c *gin.Context) {
+	api.DELETE("/meta/*name", func(c *gin.Context) {
 		name := c.Param("name")
 		slash := strings.LastIndex(name, "/")
 		if slash < 0 {
@@ -172,11 +170,11 @@ func router() *gin.Engine {
 		SetMetadata(name, m)
 	})
 
-	meta.GET("", func(c *gin.Context) {
+	api.GET("/dirtree", func(c *gin.Context) {
 		c.Params = append(c.Params, gin.Param{Key: "name", Value: "/"})
-		handleMetaGet(c)
+		handleDirtreeGet(c)
 	})
-	meta.GET("/*name", handleMetaGet)
+	api.GET("/dirtree/*name", handleDirtreeGet)
 
 	// /api/repo - download/upload
 	repo := api.Group("/repo")
@@ -440,7 +438,7 @@ func pathToDirEntry(fullpath string, e fs.DirEntry) (DirEntry, error) {
 	}
 	var url string
 	if e.IsDir() {
-		url = "/api/v1/meta" + fullpath
+		url = "/api/v1/dirtree" + fullpath
 	} else {
 		url = "/api/v1/repo" + fullpath
 	}

--- a/serve_test.go
+++ b/serve_test.go
@@ -106,7 +106,7 @@ func TestListingEntries(t *testing.T) {
 
 	// test listing
 
-	req, _ = http.NewRequest("GET", "/api/v1/meta?c=m&o=a", nil) // modtime asc
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree?c=m&o=a", nil) // modtime asc
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
@@ -150,14 +150,14 @@ func TestListingEntries(t *testing.T) {
 		ExpiryTime: 0,
 		IsDir:      true,
 		FullPath:   "/subdir",
-		Url:        "/api/v1/meta/subdir",
+		Url:        "/api/v1/dirtree/subdir",
 		Locks:      []string{},
 		Tags:       []string{},
 	}
 	assert.Equal(t, expected3, subdir)
 
 	// list subdir
-	req, _ = http.NewRequest("GET", "/api/v1/meta/subdir", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/subdir", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
@@ -185,7 +185,7 @@ func TestListingSingleFile(t *testing.T) {
 
 	router := router()
 
-	req, _ := http.NewRequest("GET", "/api/v1/meta/singlefile/a.bin", nil)
+	req, _ := http.NewRequest("GET", "/api/v1/dirtree/singlefile/a.bin", nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
@@ -201,7 +201,7 @@ func TestUrlIsCorrect(t *testing.T) {
 
 	router := router()
 
-	req, _ := http.NewRequest("GET", "/api/v1/meta/urltest", nil)
+	req, _ := http.NewRequest("GET", "/api/v1/dirtree/urltest", nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
@@ -222,35 +222,35 @@ func TestListingOrdering(t *testing.T) {
 	router := router()
 
 	// default - modtime desc
-	req, _ := http.NewRequest("GET", "/api/v1/meta/listing", nil)
+	req, _ := http.NewRequest("GET", "/api/v1/dirtree/listing", nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, []string{"c2.txt", "c.txt", "a.bin", "b.txt"}, fileNames(w.Body))
 
 	// test ordering - name desc
-	req, _ = http.NewRequest("GET", "/api/v1/meta/listing?c=n&o=d", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listing?c=n&o=d", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, []string{"c2.txt", "c.txt", "b.txt", "a.bin"}, fileNames(w.Body))
 
 	// // test ordering - name asc
-	req, _ = http.NewRequest("GET", "/api/v1/meta/listing?c=n&o=a", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listing?c=n&o=a", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, []string{"a.bin", "b.txt", "c.txt", "c2.txt"}, fileNames(w.Body))
 
 	// test ordering - modification desc
-	req, _ = http.NewRequest("GET", "/api/v1/meta/listing?c=m&o=d", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listing?c=m&o=d", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, []string{"c2.txt", "c.txt", "a.bin", "b.txt"}, fileNames(w.Body))
 
 	// test ordering - modification time asc
-	req, _ = http.NewRequest("GET", "/api/v1/meta/listing?c=m&o=a", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listing?c=m&o=a", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
@@ -264,21 +264,21 @@ func TestListingFilter(t *testing.T) {
 	router := router()
 
 	// nothing matches
-	req, _ := http.NewRequest("GET", "/api/v1/meta/listingfilter/?qt=nothing", nil)
+	req, _ := http.NewRequest("GET", "/api/v1/dirtree/listingfilter/?qt=nothing", nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, []string{}, fileNames(w.Body))
 
 	// tag with no value checks existence of tags
-	req, _ = http.NewRequest("GET", "/api/v1/meta/listingfilter?qt=branch&c=n", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listingfilter?qt=branch&c=n", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, []string{"c2.txt", "c.txt", "a.bin"}, fileNames(w.Body))
 
 	// tag with value needs matching value
-	req, _ = http.NewRequest("GET", "/api/v1/meta/listingfilter?qt=branch=dev&C=n", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listingfilter?qt=branch=dev&C=n", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
@@ -286,49 +286,49 @@ func TestListingFilter(t *testing.T) {
 
 	// lock filter
 	// filter for lock string whihc does not exists
-	req, _ = http.NewRequest("GET", "/api/v1/meta/listingfilter?ql=devel-notexist", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listingfilter?ql=devel-notexist", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, []string{}, fileNames(w.Body))
 
 	// lock with matching
-	req, _ = http.NewRequest("GET", "/api/v1/meta/listingfilter?ql=devel", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listingfilter?ql=devel", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, []string{"c.txt"}, fileNames(w.Body))
 
 	// name prefix filter
-	req, _ = http.NewRequest("GET", "/api/v1/meta/listingfilter?qn=notexist", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listingfilter?qn=notexist", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, []string{}, fileNames(w.Body))
 
 	// matching
-	req, _ = http.NewRequest("GET", "/api/v1/meta/listingfilter?qn=c", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listingfilter?qn=c", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, []string{"c2.txt", "c.txt"}, fileNames(w.Body))
 
 	// matching
-	req, _ = http.NewRequest("GET", "/api/v1/meta/listingfilter?qn=b.", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listingfilter?qn=b.", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, []string{"b.txt"}, fileNames(w.Body))
 
 	// combination - one not matching
-	req, _ = http.NewRequest("GET", "/api/v1/meta/listingfilter?qt=devel&qn=c", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listingfilter?qt=devel&qn=c", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, []string{}, fileNames(w.Body))
 
 	// combination - one matching
-	req, _ = http.NewRequest("GET", "/api/v1/meta/listingfilter?qt=branch=dev&qn=c", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listingfilter?qt=branch=dev&qn=c", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
@@ -393,7 +393,7 @@ func TestPostWithMkdir(t *testing.T) {
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
 
-	req, _ = http.NewRequest("GET", "/api/v1/meta/listing/create/me", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listing/create/me", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)

--- a/serve_test.go
+++ b/serve_test.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -21,7 +22,8 @@ func init() {
 func prepareDataDir(t *testing.T, baseDir string) error {
 	baseDir = "/" + baseDir // metadata names are saved with / prefixed
 
-	assert.NoError(t, os.RemoveAll(*dataDir))
+	clearDataDir(t)
+
 	d := path.Join(*dataDir, baseDir)
 	assert.NoError(t, os.MkdirAll(d, 0766))
 
@@ -56,55 +58,187 @@ func prepareDataDir(t *testing.T, baseDir string) error {
 	return nil
 }
 
-func filesOf(body string) []string {
-	fm := regexp.MustCompile(`href="([^"]+)"`)
-	files := fm.FindAllStringSubmatch(body, -1)
-	r := make([]string, 0)
-	for i := range files {
-		r = append(r, files[i][1])
-	}
-	return r
+func clearDataDir(t *testing.T) {
+	assert.NoError(t, os.RemoveAll(*dataDir))
+	assert.NoError(t, os.MkdirAll(*dataDir, 0766))
 }
-func TestListing(t *testing.T) {
+
+func toEntries(body *bytes.Buffer) []DirEntry {
+	var entries []DirEntry
+	if err := json.Unmarshal(body.Bytes(), &entries); err != nil {
+		return nil
+	}
+	return entries
+}
+
+func fileNames(body *bytes.Buffer) []string {
+	entries := toEntries(body)
+	if entries == nil {
+		return nil
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name)
+	}
+	return names
+}
+
+func TestListingEntries(t *testing.T) {
+
+	clearDataDir(t)
+
+	qTriggers := StartTriggers()
+	defer func() {
+		close(qTriggers)
+	}()
+
+	router := router()
+	// prepare special data
+	req, _ := http.NewRequest("POST", "/api/v1/repo/file1", strings.NewReader("file1"))
+	router.ServeHTTP(httptest.NewRecorder(), req)
+	req, _ = http.NewRequest("POST", "/api/v1/repo/fileExpireLockTag", strings.NewReader("file2"))
+	req.Header.Set("x-expire", "1h")
+	req.Header.Set("x-lock", "lock1")
+	req.Header.Set("x-tag", "tag1")
+	router.ServeHTTP(httptest.NewRecorder(), req)
+	req, _ = http.NewRequest("POST", "/api/v1/repo/subdir/fileInSubdir", strings.NewReader("file3"))
+	router.ServeHTTP(httptest.NewRecorder(), req)
+
+	// test listing
+
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree?c=m&o=a", nil) // modtime asc
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+	entries := toEntries(w.Body)
+
+	assert.Equal(t, 3, len(entries))
+
+	file1 := entries[0]
+	expected1 := DirEntry{
+		Name:       "file1",
+		Size:       5,
+		ModTime:    file1.ModTime, // testing time is hard..
+		ExpiryTime: 0,
+		IsDir:      false,
+		FullPath:   "/file1",
+		Url:        "/api/v1/repo/file1",
+		Locks:      []string{},
+		Tags:       []string{},
+	}
+	assert.Equal(t, expected1, file1)
+
+	file2 := entries[1]
+	expected2 := DirEntry{
+		Name:       "fileExpireLockTag",
+		Size:       5,
+		ModTime:    file2.ModTime,
+		ExpiryTime: uint64(time.Unix(int64(file2.ModTime), 0).Add(time.Hour).Unix()),
+		IsDir:      false,
+		FullPath:   "/fileExpireLockTag",
+		Url:        "/api/v1/repo/fileExpireLockTag",
+		Locks:      []string{"lock1"},
+		Tags:       []string{"tag1"},
+	}
+	assert.Equal(t, expected2, file2)
+
+	subdir := entries[2]
+	expected3 := DirEntry{
+		Name:       "subdir",
+		Size:       subdir.Size,
+		ModTime:    subdir.ModTime,
+		ExpiryTime: 0,
+		IsDir:      true,
+		FullPath:   "/subdir",
+		Url:        "/api/v1/dirtree/subdir",
+		Locks:      []string{},
+		Tags:       []string{},
+	}
+	assert.Equal(t, expected3, subdir)
+
+	// list subdir
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/subdir", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+	entries = toEntries(w.Body)
+	assert.Equal(t, 1, len(entries))
+	fileInSubdir := entries[0]
+	expected4 := DirEntry{
+		Name:       "fileInSubdir",
+		Size:       5,
+		ModTime:    fileInSubdir.ModTime,
+		ExpiryTime: 0,
+		IsDir:      false,
+		FullPath:   "/subdir/fileInSubdir",
+		Url:        "/api/v1/repo/subdir/fileInSubdir",
+		Locks:      []string{},
+		Tags:       []string{},
+	}
+	assert.Equal(t, expected4, fileInSubdir)
+}
+
+func TestUrlIsCorrect(t *testing.T) {
+	// test that its possible to download the file from the URL
+	err := prepareDataDir(t, "urltest")
+	assert.NoError(t, err)
+
+	router := router()
+
+	req, _ := http.NewRequest("GET", "/api/v1/dirtree/urltest", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+	entries := toEntries(w.Body)
+
+	entry := entries[0] // c2.bin
+	req, _ = http.NewRequest("GET", entry.Url, nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, "c2", w.Body.String())
+}
+
+func TestListingOrdering(t *testing.T) {
 	err := prepareDataDir(t, "listing")
 	assert.NoError(t, err)
 
 	router := router()
 
-	// default - no ordering
-	req, _ := http.NewRequest("GET", "/listing", nil)
+	// default - modtime desc
+	req, _ := http.NewRequest("GET", "/api/v1/dirtree/listing", nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.Equal(t, []string{"../", "a.bin", "c.txt", "b.txt", "c2.txt"}, filesOf(w.Body.String()))
+	assert.Equal(t, []string{"c2.txt", "c.txt", "a.bin", "b.txt"}, fileNames(w.Body))
 
 	// test ordering - name desc
-	req, _ = http.NewRequest("GET", "/listing?c=n&o=d", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listing?c=n&o=d", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.Equal(t, []string{"../", "c2.txt", "c.txt", "b.txt", "a.bin"}, filesOf(w.Body.String()))
+	assert.Equal(t, []string{"c2.txt", "c.txt", "b.txt", "a.bin"}, fileNames(w.Body))
 
 	// // test ordering - name asc
-	req, _ = http.NewRequest("GET", "/listing?c=n&o=a", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listing?c=n&o=a", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.Equal(t, []string{"../", "a.bin", "b.txt", "c.txt", "c2.txt"}, filesOf(w.Body.String()))
+	assert.Equal(t, []string{"a.bin", "b.txt", "c.txt", "c2.txt"}, fileNames(w.Body))
 
 	// test ordering - modification desc
-	req, _ = http.NewRequest("GET", "/listing?c=m&o=d", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listing?c=m&o=d", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.Equal(t, []string{"../", "c2.txt", "c.txt", "a.bin", "b.txt"}, filesOf(w.Body.String()))
+	assert.Equal(t, []string{"c2.txt", "c.txt", "a.bin", "b.txt"}, fileNames(w.Body))
 
 	// test ordering - modification time asc
-	req, _ = http.NewRequest("GET", "/listing?c=m&o=a", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listing?c=m&o=a", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.Equal(t, []string{"../", "b.txt", "a.bin", "c.txt", "c2.txt"}, filesOf(w.Body.String()))
+	assert.Equal(t, []string{"b.txt", "a.bin", "c.txt", "c2.txt"}, fileNames(w.Body))
 }
 
 func TestListingFilter(t *testing.T) {
@@ -114,76 +248,109 @@ func TestListingFilter(t *testing.T) {
 	router := router()
 
 	// nothing matches
-	req, _ := http.NewRequest("GET", "listingfilter/?qt=nothing", nil)
+	req, _ := http.NewRequest("GET", "/api/v1/dirtree/listingfilter/?qt=nothing", nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.Equal(t, []string{"../"}, filesOf(w.Body.String()))
+	assert.Equal(t, []string{}, fileNames(w.Body))
 
 	// tag with no value checks existence of tags
-	req, _ = http.NewRequest("GET", "/listingfilter?qt=branch&c=n", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listingfilter?qt=branch&c=n", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.Equal(t, []string{"../", "a.bin", "c.txt", "c2.txt"}, filesOf(w.Body.String()))
+	assert.Equal(t, []string{"c2.txt", "c.txt", "a.bin"}, fileNames(w.Body))
 
 	// tag with value needs matching value
-	req, _ = http.NewRequest("GET", "/listingfilter?qt=branch=dev&C=n", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listingfilter?qt=branch=dev&C=n", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.Equal(t, []string{"../", "c.txt"}, filesOf(w.Body.String()))
+	assert.Equal(t, []string{"c.txt"}, fileNames(w.Body))
 
 	// lock filter
 	// filter for lock string whihc does not exists
-	req, _ = http.NewRequest("GET", "/listingfilter?ql=devel-notexist", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listingfilter?ql=devel-notexist", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.Equal(t, []string{"../"}, filesOf(w.Body.String()))
+	assert.Equal(t, []string{}, fileNames(w.Body))
 
 	// lock with matching
-	req, _ = http.NewRequest("GET", "/listingfilter?ql=devel", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listingfilter?ql=devel", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.Equal(t, []string{"../", "c.txt"}, filesOf(w.Body.String()))
+	assert.Equal(t, []string{"c.txt"}, fileNames(w.Body))
 
 	// name prefix filter
-	req, _ = http.NewRequest("GET", "/listingfilter?qn=notexist", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listingfilter?qn=notexist", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.Equal(t, []string{"../"}, filesOf(w.Body.String()))
+	assert.Equal(t, []string{}, fileNames(w.Body))
 
 	// matching
-	req, _ = http.NewRequest("GET", "/listingfilter?qn=c", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listingfilter?qn=c", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.Equal(t, []string{"../", "c2.txt", "c.txt"}, filesOf(w.Body.String()))
+	assert.Equal(t, []string{"c2.txt", "c.txt"}, fileNames(w.Body))
 
 	// matching
-	req, _ = http.NewRequest("GET", "/listingfilter?qn=b.", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listingfilter?qn=b.", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.Equal(t, []string{"../", "b.txt"}, filesOf(w.Body.String()))
+	assert.Equal(t, []string{"b.txt"}, fileNames(w.Body))
 
 	// combination - one not matching
-	req, _ = http.NewRequest("GET", "/listingfilter?qt=devel&qn=c", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listingfilter?qt=devel&qn=c", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.Equal(t, []string{"../"}, filesOf(w.Body.String()))
+	assert.Equal(t, []string{}, fileNames(w.Body))
 
 	// combination - one matching
-	req, _ = http.NewRequest("GET", "/listingfilter?qt=branch=dev&qn=c", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listingfilter?qt=branch=dev&qn=c", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.Equal(t, []string{"../", "c.txt"}, filesOf(w.Body.String()))
+	assert.Equal(t, []string{"c.txt"}, fileNames(w.Body))
+}
 
+func TestRepoGet(t *testing.T) {
+	// Test that can GET a file
+	// Test that getting a non-existing file returns NotFound
+	// Test that getting a directory returns BadRequest
+	err := prepareDataDir(t, "getrequest")
+	assert.NoError(t, err)
+	qTriggers := StartTriggers()
+	defer func() {
+		close(qTriggers)
+	}()
+	router := router()
+
+	req, _ := http.NewRequest("GET", "/api/v1/repo/getrequest/a.bin", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "a", w.Body.String(), "Expected file does not match")
+
+	req, _ = http.NewRequest("GET", "/api/v1/repo/getrequest/nonexisting.bin", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code, "Getting non-existing file did not return NotFound")
+
+	req, _ = http.NewRequest("GET", "/api/v1/repo/getrequest", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code, "Getting a directory did not return BadRequest")
+	// with trailing slash
+	req, _ = http.NewRequest("GET", "/api/v1/repo/getrequest/", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code, "Getting a directory did not return BadRequest")
 }
 
 func TestPostWithMkdir(t *testing.T) {
@@ -200,29 +367,29 @@ func TestPostWithMkdir(t *testing.T) {
 
 	router := router()
 
-	req, _ := http.NewRequest("POST", "/listing/create/me/hello.txt", strings.NewReader("hello"))
+	req, _ := http.NewRequest("POST", "/api/v1/repo/listing/create/me/hello.txt", strings.NewReader("hello"))
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
 
-	req, _ = http.NewRequest("POST", "/listing/create/me/world.txt", strings.NewReader("world"))
+	req, _ = http.NewRequest("POST", "/api/v1/repo/listing/create/me/world.txt", strings.NewReader("world"))
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
 
-	req, _ = http.NewRequest("GET", "/listing/create/me", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/dirtree/listing/create/me", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.Equal(t, []string{"../", "world.txt", "hello.txt"}, filesOf(w.Body.String()))
+	assert.Equal(t, []string{"world.txt", "hello.txt"}, fileNames(w.Body))
 
-	req, _ = http.NewRequest("GET", "/listing/create/me/hello.txt", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/repo/listing/create/me/hello.txt", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, "hello", w.Body.String())
 
-	req, _ = http.NewRequest("GET", "/listing/create/me/world.txt", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/repo/listing/create/me/world.txt", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
@@ -239,12 +406,12 @@ func TestPostExisting(t *testing.T) {
 	}()
 	router := router()
 
-	req, _ := http.NewRequest("POST", "/postrequest/a.bin", strings.NewReader("not-a"))
+	req, _ := http.NewRequest("POST", "/api/v1/repo/postrequest/a.bin", strings.NewReader("not-a"))
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code, "Incorrect request when POSTing existing file")
 
-	req, _ = http.NewRequest("GET", "/postrequest/a.bin", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/repo/postrequest/a.bin", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -262,18 +429,18 @@ func TestPut(t *testing.T) {
 	router := router()
 
 	// verify that file exists
-	req, _ := http.NewRequest("GET", "/putrequest/a.bin", nil)
+	req, _ := http.NewRequest("GET", "/api/v1/repo/putrequest/a.bin", nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "a", w.Body.String(), "Expected file does not match")
 
-	req, _ = http.NewRequest("PUT", "/putrequest/a.bin", strings.NewReader("not-a"))
+	req, _ = http.NewRequest("PUT", "/api/v1/repo/putrequest/a.bin", strings.NewReader("not-a"))
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code, "PUT rejected on existing resource")
 
-	req, _ = http.NewRequest("GET", "/putrequest/a.bin", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/repo/putrequest/a.bin", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -281,12 +448,12 @@ func TestPut(t *testing.T) {
 
 	// PUT a new file
 
-	req, _ = http.NewRequest("PUT", "/putrequest/newfile", strings.NewReader("newfile"))
+	req, _ = http.NewRequest("PUT", "/api/v1/repo/putrequest/newfile", strings.NewReader("newfile"))
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code, "PUT rejected on new resource")
 
-	req, _ = http.NewRequest("GET", "/putrequest/newfile", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/repo/putrequest/newfile", nil)
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)


### PR DESCRIPTION
**BREAKING CHANGE:** old endpoints no longer work, removed functionality of text-based listing, api now moved behind /api/v1 endpoint


This is more of a proposal at this stage - this will break all existing scripts. I understand if it's rejected

Motivation: I wanted to add a delete-file endpoint, and some modify-metadata endpoints, but the current API has or requires the first part of the endpoint to be a wildcard (e.g. `router.POST("/*name")`, meaning no more POSTs can be added to the router, gin doesn't allow it. IMHO manually parsing the URL - as in the current GET request is not very extensible, so I went ahead and refactored all.

The goal was to have file-operations under `/api/v1/repo/*name` - GET/POST/PUT/DELETE, and have metadata/json operations under `/api/v1/meta/*name/tags` - POST/PUT/DELETE. 

I don't have much experience with REST APIs so all suggestions are welcome.
